### PR TITLE
Fix JSON and XML errors

### DIFF
--- a/lib/youtube-captions/captions.rb
+++ b/lib/youtube-captions/captions.rb
@@ -42,6 +42,7 @@ module YoutubeCaptions
 
     def clean_captions(captions)
       captions.map do |caption|
+        caption["__content__"] = "" if caption["__content__"].nil?
         caption.tap { |caption_hash| caption_hash["__content__"] = CGI.unescapeHTML(caption_hash["__content__"]).split.join(" ") }
       end
     end

--- a/lib/youtube-captions/info.rb
+++ b/lib/youtube-captions/info.rb
@@ -1,4 +1,5 @@
 require 'httparty'
+require 'json'
 
 module YoutubeCaptions
   class Info

--- a/lib/youtube-captions/version.rb
+++ b/lib/youtube-captions/version.rb
@@ -1,3 +1,3 @@
 module YoutubeCaptions
-  VERSION = "1.0.1"
+  VERSION = "1.0.0"
 end

--- a/lib/youtube-captions/version.rb
+++ b/lib/youtube-captions/version.rb
@@ -1,0 +1,3 @@
+module YoutubeCaptions
+  VERSION = "1.0.1"
+end

--- a/youtube-captions.gemspec
+++ b/youtube-captions.gemspec
@@ -1,9 +1,11 @@
+require_relative "lib/youtube-captions/version"
+
 Gem::Specification.new do |gem|
   gem.authors = ["Kevin S."]
   gem.files = Dir["lib/**/*.rb"]
   gem.name = "youtube-captions"
   gem.summary = "A gem to get captions of a youtube video"
-  gem.version = "1.0.0"
+  gem.version = YoutubeCaptions::VERSION
   gem.required_ruby_version = '>=2.3.0'
   gem.add_runtime_dependency "httparty"
   gem.add_runtime_dependency "nokogiri"

--- a/youtube-captions.gemspec
+++ b/youtube-captions.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |gem|
   gem.version = "1.0.0"
   gem.required_ruby_version = '>=2.3.0'
   gem.add_runtime_dependency "httparty"
+  gem.add_runtime_dependency "nokogiri"
   gem.add_development_dependency "rspec"
   gem.homepage = "https://github.com/sevinchek/youtube-captions"
 end


### PR DESCRIPTION
This PR fix the following problems

- `uninitialized constant YoutubeCaptions::Info::JSON`
- `No XML parser detected. If you're using Rubinius and Bundler, try adding an XML parser to your Gemfile (e.g. libxml-ruby, nokogiri, or rubysl-rexml). For more information, see https://github.com/sferik/multi_xml/issues/42. (MultiXml::NoParserError)`
- `caption["__content__"]` should empty if it doesn't exist.